### PR TITLE
Add circle ci basic build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/shopping_cart
+    docker:
+      - image: circleci/elixir:1.4.5
+      - image: postgres:9.4.1
+        environment:
+          POSTGRES_USER: ubuntu
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - mix-{{ .Branch }}-{{ checksum "mix.lock" }}
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+      - run: mix deps.get
+      - run: mix compile
+      - run: mix ecto.create
+      - run: mix test
+      - save_cache:
+          key: mix-{{ .Branch }}-{{ checksum "mix.lock" }}
+          paths:
+            - _build
+            - deps

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ShoppingCart
 
+[![CircleCI](https://circleci.com/gh/dstendardi/shopping_cart.svg?style=shield)](https://circleci.com/gh/dstendardi/shopping_cart)
+
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`

--- a/README.md
+++ b/README.md
@@ -2,20 +2,18 @@
 
 [![CircleCI](https://circleci.com/gh/dstendardi/shopping_cart.svg?style=shield)](https://circleci.com/gh/dstendardi/shopping_cart)
 
-To start your Phoenix server:
+## Requirements
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
-  * Start Phoenix endpoint with `mix phx.server`
+* postgres 9.6.1 or greater
+* elixir 1.4.5
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+## Install
 
-Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).
+* Download dependencies `mix deps.get`
+* Setup database `mix ecto.create && mix ecto.migrate`
+* Start server `mix phx.server`
 
-## Learn more
+## Run the tests
 
-  * Official website: http://www.phoenixframework.org/
-  * Guides: http://phoenixframework.org/docs/overview
-  * Docs: https://hexdocs.pm/phoenix
-  * Mailing list: http://groups.google.com/group/phoenix-talk
-  * Source: https://github.com/phoenixframework/phoenix
+* Run all the tests `mix test`
+

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ShoppingCart.Mixfile do
     [
       app: :shopping_cart,
       version: "0.0.1",
-      elixir: "~> 1.4",
+      elixir: "~> 1.4.5",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix, :gettext] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
This PR setup the basic configuration for building and testing on circle ci.
It does not provide yet deployment automation.

Things to note : 
 * the cache key derived from branch name and a checksum of the `mix.lock` file
 * we cache both `build` and `_deps` folder
 * version of elixir is 1.4.5 (latest supported by circle ci so far)